### PR TITLE
feat(config): Env overrides for all standard config values

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: test
+
+on:
+  push:
+    branches: [ main, dev ]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: OVOS Message bus Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: setup toolchain
+        uses: hecrj/setup-rust-action@v2
+        with:
+          rust-version: stable
+
+      - name: cargo test
+        run: cargo test --all-features -- --test-threads=1
+
+      - name: rustfmt
+        run: cargo fmt --all -- --check
+
+      - name: clippy
+        run: cargo clippy --all --all-features --tests -- -D warnings

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ OVOS_BUS_HOST=10.10.10.10 OVOS_BUS_PORT=8181 /usr/local/bin/ovos_messagebus
 - `OVOS_BUS_PORT` (default: `8181`)
 - `OVOS_BUS_CONFIG_FILE` (default: none)
 - `OVOS_BUS_MAX_MSG_SIZE` (default: `25`, in MB)
+- `OVOS_BUS_ROUTE` (default: `/core`)
+- `OVOS_BUS_USE_SSL` (default: `false`) NOTE: If the environment variable exists SSL will be enabled.
 
 Environment variables take precedence over settings in the configuration file.
 
@@ -102,7 +104,7 @@ To run the test suite:
 cargo test
 ```
 
-...except we don't have tests. Please feel free to contribute!
+...except we don't have very many tests. Please feel free to contribute!
 
 ### Contributing
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,12 @@ impl Config {
                 config.max_msg_size = size;
             }
         }
+        if let Ok(route) = env::var("OVOS_BUS_ROUTE") {
+            config.route = route;
+        }
+        if env::var("OVOS_BUS_USE_SSL").is_ok() {
+            config.ssl = true;
+        }
 
         config
     }
@@ -113,7 +119,8 @@ mod tests {
         env::remove_var("OVOS_BUS_CONFIG_FILE");
         env::remove_var("OVOS_BUS_PORT");
         env::remove_var("OVOS_BUS_HOST");
-        env::remove_var("OVOS_BUS_MAX_MSG_SIZE");
+        env::remove_var("OVOS_BUS_ROUTE");
+        env::remove_var("OVOS_BUS_USE_SSL");
     }
 
     #[serial]
@@ -124,6 +131,8 @@ mod tests {
         assert_eq!(test_conf.host, "127.0.0.1".to_string());
         assert_eq!(test_conf.port, 8181);
         assert_eq!(test_conf.route, "/core".to_string());
+        assert_eq!(test_conf.max_msg_size, 25);
+        assert!(!test_conf.ssl);
     }
 
     #[serial]
@@ -133,11 +142,15 @@ mod tests {
         env::set_var("OVOS_BUS_PORT", "1337");
         env::set_var("OVOS_BUS_HOST", "battle.net");
         env::set_var("OVOS_BUS_MAX_MSG_SIZE", "42");
+        env::set_var("OVOS_BUS_ROUTE", "/modermodemet");
+        env::set_var("OVOS_BUS_USE_SSL", "true");
 
         let test_conf = Config::new();
         assert_eq!(test_conf.port, 1337);
         assert_eq!(test_conf.host, "battle.net".to_string());
         assert_eq!(test_conf.max_msg_size, 42);
+        assert_eq!(test_conf.route, "/modermodemet");
+        assert!(test_conf.ssl);
     }
 
     fn setup_test_config() {
@@ -146,6 +159,7 @@ mod tests {
         env::set_var("OVOS_BUS_CONFIG_FILE", d);
         println!("config is {}", env::var("OVOS_BUS_CONFIG_FILE").unwrap());
     }
+
     #[serial]
     #[test]
     fn test_config_file() {


### PR DESCRIPTION
This adds env overrides for the missing config options (excluding "extras") and may possibly resolve #12.

To note: OVOS_BUS_USE_SSL will set the ssl-flag if the environment variable exists. The parsing of bools seemed a bit limited using the standard `.parse()` so instead of requiring it to be EXACTLY `true` this felt like a more safe way.