### PR TITLE
chore: fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main, dev ]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/OscillateLabsLLC/ovos-rust-messagebus/security/code-scanning/1](https://github.com/OscillateLabsLLC/ovos-rust-messagebus/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block for the workflow or the specific job so that the `GITHUB_TOKEN` has only the minimal scopes needed. For this workflow, the job only checks out the repository and runs `cargo` commands; no write operations to the repository or other GitHub resources are performed, so `contents: read` is sufficient.

The best fix with minimal functional impact is to add a `permissions` section at the workflow root (top level, alongside `name`, `on`, `env`, and `jobs`). This will apply to all jobs in this workflow, including the `test` job, and will restrict the `GITHUB_TOKEN` to read-only access to repository contents. Concretely, in `.github/workflows/test.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `env:` block (e.g., after line 6). This does not require any imports or other definitions, just the YAML keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
