### PR TITLE
perf: remove unused hot-path work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.24"
 serde = { version = "1.0", features = ["derive"] }
-EventEmitter = "0.0.4"
 futures-util = "0.3"
 serde_yaml = "0.9.34"
 jsonc-parser = "0.23.0"

--- a/src/message_bus.rs
+++ b/src/message_bus.rs
@@ -2,17 +2,15 @@ use futures_util::{SinkExt, StreamExt};
 use std::sync::{Arc, Mutex};
 use tokio::net::TcpListener;
 use tokio::sync::mpsc::{self, UnboundedSender};
-use tokio_tungstenite::accept_async;
-use tokio_tungstenite::tungstenite::protocol::Message;
+use tokio_tungstenite::accept_async_with_config;
+use tokio_tungstenite::tungstenite::protocol::{Message, WebSocketConfig};
 
 use crate::config::Config;
-use EventEmitter::EventEmitter;
 
 #[derive(Clone)]
 pub struct MessageBus {
     config: Arc<Config>,
     connections: Arc<Mutex<Vec<UnboundedSender<Message>>>>,
-    event_emitter: Arc<Mutex<EventEmitter>>,
 }
 
 impl MessageBus {
@@ -20,7 +18,6 @@ impl MessageBus {
         Self {
             config: Arc::new(config),
             connections: Arc::new(Mutex::new(Vec::new())),
-            event_emitter: Arc::new(Mutex::new(EventEmitter::new())),
         }
     }
 
@@ -48,7 +45,8 @@ impl MessageBus {
         &self,
         stream: tokio::net::TcpStream,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let ws_stream = accept_async(stream).await?;
+        stream.set_nodelay(true)?;
+        let ws_stream = accept_async_with_config(stream, Some(self.websocket_config())).await?;
         let (tx, mut rx) = mpsc::unbounded_channel();
         let tx_clone = tx.clone();
         {
@@ -63,17 +61,9 @@ impl MessageBus {
             while let Some(message) = read.next().await {
                 match message {
                     Ok(Message::Text(text)) => {
-                        if text.len() as u32 > read_bus.config.max_msg_size * 1024 * 1024 {
-                            eprintln!("Message size exceeds maximum allowed size");
-                            break;
-                        }
-                        println!("Received message: {}", text);
                         read_bus.broadcast_message(&text).await;
-                        let event_emitter = read_bus.event_emitter.lock().unwrap();
-                        event_emitter.emit(&text);
                     }
                     Ok(Message::Close(_)) => {
-                        println!("WebSocket connection closed");
                         break;
                     }
                     Ok(_) => {}
@@ -111,5 +101,13 @@ impl MessageBus {
     async fn remove_connection(&self, tx: &UnboundedSender<Message>) {
         let mut connections = self.connections.lock().unwrap();
         connections.retain(|conn| !conn.same_channel(tx));
+    }
+
+    fn websocket_config(&self) -> WebSocketConfig {
+        let max_message_size = self.config.max_msg_size as usize * 1024 * 1024;
+        let mut config = WebSocketConfig::default();
+        config.max_message_size = Some(max_message_size);
+        config.max_frame_size = Some(max_message_size);
+        config
     }
 }


### PR DESCRIPTION
## TL;DR
This PR is mostly a hot-path cleanup and correctness pass, not the main throughput win.

It does four things:
- removes the unused `EventEmitter` from the message path
- stops logging every received and closed websocket message on the hot path
- enables `TCP_NODELAY` on accepted sockets
- moves max websocket message-size enforcement into tungstenite config so oversized messages are rejected earlier

Tradeoff:
- on the Pi benchmark below, this PR alone does **not** improve steady-state throughput
- that is expected, because it does not yet change the real broadcast bottlenecks: the global connection lock and per-subscriber message cloning
- those are handled in the follow-up PRs

## Benchmarks
Incremental benchmark for this branch versus `03bfb0a3fe29a1f26762a972cf6f2948ddd1b7ef` on a Raspberry Pi 4B (`aarch64`).

Method:
- host: `goldyfruit@10.17.2.64`
- harness: `benchmarks_compare_servers.py`
- 1 warmup + 3 measured trials per scenario
- background OVOS services were still running on the Pi

Units:
- each percentage below is the change in **median delivered messages per second** versus the baseline

Why `1`, `16`, and `32` subscribers:
- the bus fanout cost scales with the number of recipients, so these are low, medium, and higher fanout checkpoints rather than arbitrary values

Results:

| Scenario | Change in median delivered msgs/sec |
| --- | ---: |
| 1 subscriber, 5000 msgs, 256 B | +1.20% |
| 16 subscribers, 5000 msgs, 256 B | -3.05% |
| 16 subscribers, 500 msgs, 4 KiB | -3.17% |
| 32 subscribers, 500 msgs, 8 KiB | -4.03% |
| 32 subscribers, 1000 msgs, 8 KiB | -0.65% |

Weighted overall across this suite: `-2.11%`

Notes:
- this PR mainly removes unused work and moves the size check earlier in websocket processing
- on this Pi, those cleanup changes alone did not improve steady-state throughput without the later queue and batching changes
