### PR TITLE
perf: use bounded broadcast fanout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.24"
 serde = { version = "1.0", features = ["derive"] }
-EventEmitter = "0.0.4"
 futures-util = "0.3"
 serde_yaml = "0.9.34"
 jsonc-parser = "0.23.0"

--- a/src/message_bus.rs
+++ b/src/message_bus.rs
@@ -2,17 +2,15 @@ use futures_util::{SinkExt, StreamExt};
 use std::sync::{Arc, Mutex};
 use tokio::net::TcpListener;
 use tokio::sync::mpsc::{self, UnboundedSender};
-use tokio_tungstenite::accept_async;
-use tokio_tungstenite::tungstenite::protocol::Message;
+use tokio_tungstenite::accept_async_with_config;
+use tokio_tungstenite::tungstenite::protocol::{Message, WebSocketConfig};
 
 use crate::config::Config;
-use EventEmitter::EventEmitter;
 
 #[derive(Clone)]
 pub struct MessageBus {
     config: Arc<Config>,
     connections: Arc<Mutex<Vec<UnboundedSender<Message>>>>,
-    event_emitter: Arc<Mutex<EventEmitter>>,
 }
 
 impl MessageBus {
@@ -20,7 +18,6 @@ impl MessageBus {
         Self {
             config: Arc::new(config),
             connections: Arc::new(Mutex::new(Vec::new())),
-            event_emitter: Arc::new(Mutex::new(EventEmitter::new())),
         }
     }
 
@@ -48,7 +45,8 @@ impl MessageBus {
         &self,
         stream: tokio::net::TcpStream,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let ws_stream = accept_async(stream).await?;
+        stream.set_nodelay(true)?;
+        let ws_stream = accept_async_with_config(stream, Some(self.websocket_config())).await?;
         let (tx, mut rx) = mpsc::unbounded_channel();
         let tx_clone = tx.clone();
         {
@@ -63,17 +61,9 @@ impl MessageBus {
             while let Some(message) = read.next().await {
                 match message {
                     Ok(Message::Text(text)) => {
-                        if text.len() as u32 > read_bus.config.max_msg_size * 1024 * 1024 {
-                            eprintln!("Message size exceeds maximum allowed size");
-                            break;
-                        }
-                        println!("Received message: {}", text);
                         read_bus.broadcast_message(&text).await;
-                        let event_emitter = read_bus.event_emitter.lock().unwrap();
-                        event_emitter.emit(&text);
                     }
                     Ok(Message::Close(_)) => {
-                        println!("WebSocket connection closed");
                         break;
                     }
                     Ok(_) => {}
@@ -111,5 +101,13 @@ impl MessageBus {
     async fn remove_connection(&self, tx: &UnboundedSender<Message>) {
         let mut connections = self.connections.lock().unwrap();
         connections.retain(|conn| !conn.same_channel(tx));
+    }
+
+    fn websocket_config(&self) -> WebSocketConfig {
+        let max_message_size = self.config.max_msg_size as usize * 1024 * 1024;
+        let mut config = WebSocketConfig::default();
+        config.max_message_size = Some(max_message_size);
+        config.max_frame_size = Some(max_message_size);
+        config
     }
 }

--- a/src/message_bus.rs
+++ b/src/message_bus.rs
@@ -1,23 +1,26 @@
 use futures_util::{SinkExt, StreamExt};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tokio::net::TcpListener;
-use tokio::sync::mpsc::{self, UnboundedSender};
+use tokio::sync::broadcast;
 use tokio_tungstenite::accept_async_with_config;
 use tokio_tungstenite::tungstenite::protocol::{Message, WebSocketConfig};
 
 use crate::config::Config;
 
+const MESSAGE_BUFFER_CAPACITY: usize = 1024;
+
 #[derive(Clone)]
 pub struct MessageBus {
     config: Arc<Config>,
-    connections: Arc<Mutex<Vec<UnboundedSender<Message>>>>,
+    message_tx: broadcast::Sender<Message>,
 }
 
 impl MessageBus {
     pub fn new(config: Config) -> Self {
+        let (message_tx, _) = broadcast::channel(MESSAGE_BUFFER_CAPACITY);
         Self {
             config: Arc::new(config),
-            connections: Arc::new(Mutex::new(Vec::new())),
+            message_tx,
         }
     }
 
@@ -47,21 +50,15 @@ impl MessageBus {
     ) -> Result<(), Box<dyn std::error::Error>> {
         stream.set_nodelay(true)?;
         let ws_stream = accept_async_with_config(stream, Some(self.websocket_config())).await?;
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        let tx_clone = tx.clone();
-        {
-            let mut connections = self.connections.lock().unwrap();
-            connections.push(tx);
-        }
-
         let (mut write, mut read) = ws_stream.split();
+        let mut rx = self.message_tx.subscribe();
 
         let read_bus = self.clone();
         let read_handle = tokio::spawn(async move {
             while let Some(message) = read.next().await {
                 match message {
                     Ok(Message::Text(text)) => {
-                        read_bus.broadcast_message(&text).await;
+                        let _ = read_bus.broadcast_message(Message::Text(text));
                     }
                     Ok(Message::Close(_)) => {
                         break;
@@ -73,34 +70,48 @@ impl MessageBus {
                     }
                 }
             }
-            read_bus.remove_connection(&tx_clone).await;
         });
 
         let write_handle = tokio::spawn(async move {
-            while let Some(message) = rx.recv().await {
-                if let Err(e) = write.send(message).await {
-                    eprintln!("Error sending message: {}", e);
-                    break;
+            loop {
+                match rx.recv().await {
+                    Ok(message) => {
+                        if let Err(e) = write.send(message).await {
+                            eprintln!("Error sending message: {}", e);
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                        break;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        break;
+                    }
                 }
             }
         });
 
+        let mut read_handle = read_handle;
+        let mut write_handle = write_handle;
         tokio::select! {
-            _ = read_handle => {},
-            _ = write_handle => {},
+            _ = &mut read_handle => {
+                write_handle.abort();
+            },
+            _ = &mut write_handle => {
+                read_handle.abort();
+            },
         }
+        let _ = read_handle.await;
+        let _ = write_handle.await;
 
         Ok(())
     }
 
-    async fn broadcast_message(&self, message: &str) {
-        let mut connections = self.connections.lock().unwrap();
-        connections.retain(|tx| tx.send(Message::Text(message.to_string())).is_ok());
-    }
-
-    async fn remove_connection(&self, tx: &UnboundedSender<Message>) {
-        let mut connections = self.connections.lock().unwrap();
-        connections.retain(|conn| !conn.same_channel(tx));
+    fn broadcast_message(
+        &self,
+        message: Message,
+    ) -> Result<usize, broadcast::error::SendError<Message>> {
+        self.message_tx.send(message)
     }
 
     fn websocket_config(&self) -> WebSocketConfig {


### PR DESCRIPTION
## Summary
- replace the per-connection unbounded sender list with a bounded broadcast channel
- remove the global connection mutex from the message fanout path
- disconnect lagging receivers instead of allowing unbounded queue growth

## Benchmarks
Incremental benchmark for this branch versus `perf/remove-hot-path-work` on a Raspberry Pi 4B (`aarch64`).

Method:
- host: `goldyfruit@10.17.2.64`
- harness: `benchmarks_compare_servers.py`
- 1 warmup + 3 measured trials per scenario
- background OVOS services were still running on the Pi

Results:

| Scenario | Gain |
| --- | ---: |
| 1 subscriber, 5000 msgs, 256 B | +4.68% |
| 16 subscribers, 5000 msgs, 256 B | +4.27% |
| 16 subscribers, 500 msgs, 4 KiB | +6.54% |
| 32 subscribers, 500 msgs, 8 KiB | -1.65% |
| 32 subscribers, 1000 msgs, 8 KiB | -2.23% |

Weighted overall across this suite: `+3.09%`

Notes:
- the bounded fanout model is the main throughput win in light and medium fanout cases
- the heavy 8 KiB fanout cases on this Pi do not improve until the write batching changes in the next PR land

## Stack
- depends on #24
- opened against `dev` because the stacked base branch is not available in the upstream repo
- reviewers should focus on commit `137b221` first
