### PR TITLE
feat!: perf/broadcast refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43375ec7f968f9122d709c807fa6bcc305430f62da0a0973c8d33827c4f7b75b"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +222,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7725c320caac8c21d8228c1d055af27a995d371f78cc763073d3e068323641b5"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +249,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +271,15 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -269,6 +302,8 @@ dependencies = [
  "serial_test",
  "tokio",
  "tokio-tungstenite",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -371,6 +406,23 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "ryu"
@@ -493,6 +545,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +663,67 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -636,6 +767,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "EventEmitter"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43375ec7f968f9122d709c807fa6bcc305430f62da0a0973c8d33827c4f7b75b"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,7 +287,6 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 name = "ovos_messagebus"
 version = "1.1.2"
 dependencies = [
- "EventEmitter",
  "futures-util",
  "jsonc-parser",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,13 +156,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -362,21 +357,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom",
 ]
@@ -591,18 +591,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -648,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -721,11 +721,10 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
@@ -778,6 +777,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "windows-link"
@@ -867,6 +875,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.24"
 serde = { version = "1.0", features = ["derive"] }
-EventEmitter = "0.0.4"
 futures-util = "0.3"
 serde_yaml = "0.9.34"
 jsonc-parser = "0.23.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
-tokio-tungstenite = "0.24"
+tokio-tungstenite = "0.28"
 serde = { version = "1.0", features = ["derive"] }
 futures-util = "0.3"
 serde_yaml = "0.9.34"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ futures-util = "0.3"
 serde_yaml = "0.9.34"
 jsonc-parser = "0.23.0"
 serde_json = "1.0.122"
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
 [dev-dependencies]
 serial_test = "3.2.0"

--- a/README.md
+++ b/README.md
@@ -67,12 +67,36 @@ OVOS_BUS_HOST=10.10.10.10 OVOS_BUS_PORT=8181 /usr/local/bin/ovos_messagebus
 - `OVOS_BUS_MAX_MSG_SIZE` (default: `25`, in MB)
 - `OVOS_BUS_ROUTE` (default: `/core`)
 - `OVOS_BUS_USE_SSL` (default: `false`) NOTE: If the environment variable exists SSL will be enabled.
+- `OVOS_BUS_MSG_BUFFER_CAPACITY` (default: `1024`) — the broadcast channel buffer size. See [Architecture](#architecture) for details.
+- `RUST_LOG` (default: unset) — controls log verbosity. Examples: `RUST_LOG=info` for startup and connection events, `RUST_LOG=debug` for connection lifecycle, `RUST_LOG=trace` for per-message logging.
 
 Environment variables take precedence over settings in the configuration file.
 
 ### Additional Configuration
 
 Any other settings must be configured in `mycroft.conf` or a similar OVOS-compatible configuration file.
+
+## Architecture
+
+The messagebus uses a `tokio::sync::broadcast` channel for fan-out. When a client sends a message, it's placed into a single shared broadcast channel, and every connected subscriber receives a clone. Because `Utf8Bytes` (tungstenite 0.28) is backed by an `Arc`, cloning a message to N subscribers is N reference count increments, not N string copies.
+
+Outbound writes are batched: the write loop collects up to 64 pending messages (or 256KB, whichever comes first) and flushes them in a single syscall, reducing per-message overhead under load.
+
+### Slow consumer policy
+
+The broadcast buffer has a fixed capacity (default 1024 messages, configurable via `OVOS_BUS_MSG_BUFFER_CAPACITY` or `message_buffer_capacity` in the config file). If a subscriber falls behind by more than this many messages, it is disconnected rather than allowed to accumulate unbounded backlog.
+
+This is an intentional tradeoff: it caps memory usage and prevents one stalled client from degrading the bus for everyone else, at the cost of dropping that client's connection. For typical OVOS workloads (sequential conversational traffic at 10-50 messages/sec), a client would need to be completely unresponsive for 20-100 seconds before hitting the limit. The default of 1024 is appropriate for most deployments. Increase it if you have a workload with sustained high-throughput bursts where temporary receiver lag is expected and acceptable.
+
+### Connection handling
+
+TCP listen backlog is set to 1024 to handle burst connection scenarios (100+ simultaneous clients). `TCP_NODELAY` is enabled on all accepted sockets to minimize latency. Max message size is enforced at the tungstenite protocol layer — oversized frames are rejected before reaching application code, and the error is logged with the actual size, limit, and the config knob to change it.
+
+### What this doesn't do
+
+**Server-side WebSocket pings.** The server does not send ping frames. Dead connections are detected when the next write fails or when the OS TCP keepalive fires. This means a client that silently disappears (network drop, OOM kill) will hold its broadcast subscription open until the TCP stack notices. In practice this is harmless — the subscription sits idle and gets cleaned up on the next failed write — but it means the server won't proactively notice a dead client. Client-side keepalive (which most WebSocket libraries enable by default) covers this in the other direction.
+
+**Per-message routing or filtering.** Every message is broadcast to every connected client. There is no topic-based subscription or message filtering at the server level. This matches the OVOS bus protocol where all components see all traffic.
 
 ## Docker
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::env;
 use std::fs;
+use tracing::{error, warn};
 
 use crate::utils::remove_comments;
 
@@ -49,7 +50,7 @@ impl Config {
             if let Ok(contents) = fs::read_to_string(config_file) {
                 config = Self::parse_config(&contents, config);
             } else {
-                eprintln!("Failed to read config file. Using defaults.");
+                warn!("Failed to read config file. Using defaults.");
             }
         }
 
@@ -86,7 +87,7 @@ impl Config {
                 match serde_yaml::from_str::<RootConfig>(&cleaned_contents) {
                     Ok(root_config) => Self::apply_config(root_config, config),
                     Err(e) => {
-                        eprintln!("Failed to parse config file even after removing comments: {}. Using defaults.", e);
+                        error!("Failed to parse config file even after removing comments: {}. Using defaults.", e);
                         config
                     }
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -115,7 +115,9 @@ impl Config {
             config.route = websocket_config.route.unwrap_or(config.route);
             config.ssl = websocket_config.ssl.unwrap_or(config.ssl);
             config.max_msg_size = websocket_config.max_msg_size.unwrap_or(config.max_msg_size);
-            config.message_buffer_capacity = websocket_config.message_buffer_capacity.unwrap_or(config.message_buffer_capacity);
+            config.message_buffer_capacity = websocket_config
+                .message_buffer_capacity
+                .unwrap_or(config.message_buffer_capacity);
             config.extra = websocket_config.extra;
         }
         config

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,8 +13,14 @@ pub struct Config {
     pub route: String,
     pub ssl: bool,
     pub max_msg_size: u32,
+    #[serde(default = "default_message_buffer")]
+    pub message_buffer_capacity: usize,
     #[serde(flatten)]
     pub extra: HashMap<String, serde_yaml::Value>,
+}
+
+fn default_message_buffer() -> usize {
+    1024
 }
 
 #[derive(Deserialize)]
@@ -29,6 +35,7 @@ struct WebSocketConfig {
     route: Option<String>,
     ssl: Option<bool>,
     max_msg_size: Option<u32>,
+    message_buffer_capacity: Option<usize>,
     #[serde(flatten)]
     extra: HashMap<String, serde_yaml::Value>,
 }
@@ -42,6 +49,7 @@ impl Config {
             route: "/core".to_string(),
             ssl: false,
             max_msg_size: 25,
+            message_buffer_capacity: default_message_buffer(),
             extra: HashMap::new(),
         };
 
@@ -70,6 +78,11 @@ impl Config {
         }
         if let Ok(route) = env::var("OVOS_BUS_ROUTE") {
             config.route = route;
+        }
+        if let Ok(buf_cap) = env::var("OVOS_BUS_MSG_BUFFER_CAPACITY") {
+            if let Ok(cap) = buf_cap.parse() {
+                config.message_buffer_capacity = cap;
+            }
         }
         if env::var("OVOS_BUS_USE_SSL").is_ok() {
             config.ssl = true;
@@ -102,6 +115,7 @@ impl Config {
             config.route = websocket_config.route.unwrap_or(config.route);
             config.ssl = websocket_config.ssl.unwrap_or(config.ssl);
             config.max_msg_size = websocket_config.max_msg_size.unwrap_or(config.max_msg_size);
+            config.message_buffer_capacity = websocket_config.message_buffer_capacity.unwrap_or(config.message_buffer_capacity);
             config.extra = websocket_config.extra;
         }
         config
@@ -123,6 +137,7 @@ mod tests {
         env::remove_var("OVOS_BUS_ROUTE");
         env::remove_var("OVOS_BUS_USE_SSL");
         env::remove_var("OVOS_BUS_MAX_MSG_SIZE");
+        env::remove_var("OVOS_BUS_MSG_BUFFER_CAPACITY");
     }
 
     #[serial]
@@ -134,6 +149,7 @@ mod tests {
         assert_eq!(test_conf.port, 8181);
         assert_eq!(test_conf.route, "/core".to_string());
         assert_eq!(test_conf.max_msg_size, 25);
+        assert_eq!(test_conf.message_buffer_capacity, 1024);
         assert!(!test_conf.ssl);
     }
 
@@ -146,12 +162,14 @@ mod tests {
         env::set_var("OVOS_BUS_MAX_MSG_SIZE", "42");
         env::set_var("OVOS_BUS_ROUTE", "/modermodemet");
         env::set_var("OVOS_BUS_USE_SSL", "true");
+        env::set_var("OVOS_BUS_MSG_BUFFER_CAPACITY", "4096");
 
         let test_conf = Config::new();
         assert_eq!(test_conf.port, 1337);
         assert_eq!(test_conf.host, "battle.net".to_string());
         assert_eq!(test_conf.max_msg_size, 42);
         assert_eq!(test_conf.route, "/modermodemet");
+        assert_eq!(test_conf.message_buffer_capacity, 4096);
         assert!(test_conf.ssl);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,14 @@ mod utils;
 
 use crate::config::Config;
 use crate::message_bus::MessageBus;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
     let config = Config::new();
     let message_bus = MessageBus::new(config);
     message_bus.run().await?;

--- a/src/message_bus.rs
+++ b/src/message_bus.rs
@@ -4,6 +4,7 @@ use tokio::net::TcpListener;
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio_tungstenite::accept_async;
 use tokio_tungstenite::tungstenite::protocol::Message;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::config::Config;
 use EventEmitter::EventEmitter;
@@ -27,7 +28,7 @@ impl MessageBus {
     pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
         let addr = format!("{}:{}", self.config.host, self.config.port);
         let listener = TcpListener::bind(&addr).await?;
-        println!(
+        info!(
             "MessageBus listening on {} (route: {})",
             addr, self.config.route
         );
@@ -36,7 +37,7 @@ impl MessageBus {
             let bus_clone = self.clone();
             tokio::spawn(async move {
                 if let Err(e) = bus_clone.handle_connection(stream).await {
-                    eprintln!("Error handling connection: {}", e);
+                    error!("Error handling connection: {}", e);
                 }
             });
         }
@@ -55,6 +56,7 @@ impl MessageBus {
             let mut connections = self.connections.lock().unwrap();
             connections.push(tx);
         }
+        debug!("WebSocket connection opened (total: {})", self.connections.lock().unwrap().len());
 
         let (mut write, mut read) = ws_stream.split();
 
@@ -64,21 +66,21 @@ impl MessageBus {
                 match message {
                     Ok(Message::Text(text)) => {
                         if text.len() as u32 > read_bus.config.max_msg_size * 1024 * 1024 {
-                            eprintln!("Message size exceeds maximum allowed size");
+                            warn!("Message size exceeds maximum allowed size");
                             break;
                         }
-                        println!("Received message: {}", text);
+                        trace!("Received message: {}", text);
                         read_bus.broadcast_message(&text).await;
                         let event_emitter = read_bus.event_emitter.lock().unwrap();
                         event_emitter.emit(&text);
                     }
                     Ok(Message::Close(_)) => {
-                        println!("WebSocket connection closed");
+                        debug!("WebSocket connection closed");
                         break;
                     }
                     Ok(_) => {}
                     Err(e) => {
-                        eprintln!("WebSocket error: {}", e);
+                        error!("WebSocket error: {}", e);
                         break;
                     }
                 }
@@ -89,7 +91,7 @@ impl MessageBus {
         let write_handle = tokio::spawn(async move {
             while let Some(message) = rx.recv().await {
                 if let Err(e) = write.send(message).await {
-                    eprintln!("Error sending message: {}", e);
+                    error!("Error sending message: {}", e);
                     break;
                 }
             }

--- a/src/message_bus.rs
+++ b/src/message_bus.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use tokio::net::TcpSocket;
 use tokio::sync::broadcast::{self, error::RecvError, error::TryRecvError, Receiver};
 use tokio_tungstenite::accept_async_with_config;
-use tokio_tungstenite::tungstenite::{error::CapacityError, protocol::WebSocketConfig, Error as WsError, Message, Utf8Bytes};
+use tokio_tungstenite::tungstenite::{
+    error::CapacityError, protocol::WebSocketConfig, Error as WsError, Message, Utf8Bytes,
+};
 use tracing::{debug, error, info, trace, warn};
 
 use crate::config::Config;
@@ -64,7 +66,10 @@ impl MessageBus {
         let (mut write, mut read) = ws_stream.split();
         let mut rx = self.message_tx.subscribe();
 
-        debug!("WebSocket connection opened (subscribers: {})", self.message_tx.receiver_count());
+        debug!(
+            "WebSocket connection opened (subscribers: {})",
+            self.message_tx.receiver_count()
+        );
 
         let read_bus = self.clone();
         let mut read_handle = tokio::spawn(async move {
@@ -106,7 +111,10 @@ impl MessageBus {
                 {
                     Ok(BatchState::Continue) => {}
                     Ok(BatchState::SlowConsumer(skipped)) => {
-                        warn!("Slow consumer lagged, dropped {} messages — disconnecting", skipped);
+                        warn!(
+                            "Slow consumer lagged, dropped {} messages — disconnecting",
+                            skipped
+                        );
                         break;
                     }
                     Ok(BatchState::Closed) => {

--- a/src/message_bus.rs
+++ b/src/message_bus.rs
@@ -71,6 +71,13 @@ impl MessageBus {
             self.message_tx.receiver_count()
         );
 
+        // Send the OVOS "connected" greeting expected by all bus clients
+        let greeting = r#"{"msg_type": "connected", "data": {}, "context": {"session": {"session_id": "default"}}}"#;
+        if let Err(e) = write.send(Message::Text(greeting.into())).await {
+            error!("Failed to send greeting: {}", e);
+            return Ok(());
+        }
+
         let read_bus = self.clone();
         let mut read_handle = tokio::spawn(async move {
             while let Some(message) = read.next().await {

--- a/src/message_bus.rs
+++ b/src/message_bus.rs
@@ -4,12 +4,11 @@ use std::sync::Arc;
 use tokio::net::TcpSocket;
 use tokio::sync::broadcast::{self, error::RecvError, error::TryRecvError, Receiver};
 use tokio_tungstenite::accept_async_with_config;
-use tokio_tungstenite::tungstenite::{protocol::WebSocketConfig, Message, Utf8Bytes};
+use tokio_tungstenite::tungstenite::{error::CapacityError, protocol::WebSocketConfig, Error as WsError, Message, Utf8Bytes};
 use tracing::{debug, error, info, trace, warn};
 
 use crate::config::Config;
 
-const MESSAGE_BUFFER_CAPACITY: usize = 1024;
 const TCP_BACKLOG: u32 = 1024;
 const WRITE_BATCH_SIZE: usize = 64;
 const WRITE_BATCH_BYTES_LIMIT: usize = 256 * 1024;
@@ -22,7 +21,7 @@ pub struct MessageBus {
 
 impl MessageBus {
     pub fn new(config: Config) -> Self {
-        let (message_tx, _) = broadcast::channel(MESSAGE_BUFFER_CAPACITY);
+        let (message_tx, _) = broadcast::channel(config.message_buffer_capacity);
         Self {
             config: Arc::new(config),
             message_tx,
@@ -68,7 +67,7 @@ impl MessageBus {
         debug!("WebSocket connection opened (subscribers: {})", self.message_tx.receiver_count());
 
         let read_bus = self.clone();
-        let read_handle = tokio::spawn(async move {
+        let mut read_handle = tokio::spawn(async move {
             while let Some(message) = read.next().await {
                 match message {
                     Ok(Message::Text(text)) => {
@@ -80,6 +79,13 @@ impl MessageBus {
                         break;
                     }
                     Ok(_) => {}
+                    Err(WsError::Capacity(CapacityError::MessageTooLong { size, max_size })) => {
+                        error!(
+                            "Message too large: {} bytes exceeds {} byte limit (max_msg_size: {} MB)",
+                            size, max_size, read_bus.config.max_msg_size
+                        );
+                        break;
+                    }
                     Err(e) => {
                         error!("WebSocket error: {}", e);
                         break;
@@ -88,7 +94,7 @@ impl MessageBus {
             }
         });
 
-        let write_handle = tokio::spawn(async move {
+        let mut write_handle = tokio::spawn(async move {
             loop {
                 match flush_next_batch(
                     &mut write,
@@ -114,18 +120,16 @@ impl MessageBus {
             }
         });
 
-        let mut read_handle = read_handle;
-        let mut write_handle = write_handle;
         tokio::select! {
             _ = &mut read_handle => {
                 write_handle.abort();
+                let _ = write_handle.await;
             },
             _ = &mut write_handle => {
                 read_handle.abort();
+                let _ = read_handle.await;
             },
         }
-        let _ = read_handle.await;
-        let _ = write_handle.await;
 
         Ok(())
     }

--- a/src/message_bus.rs
+++ b/src/message_bus.rs
@@ -1,6 +1,7 @@
 use futures_util::{Sink, SinkExt, StreamExt};
+use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::net::TcpListener;
+use tokio::net::TcpSocket;
 use tokio::sync::broadcast::{self, error::RecvError, error::TryRecvError, Receiver};
 use tokio_tungstenite::accept_async_with_config;
 use tokio_tungstenite::tungstenite::{protocol::WebSocketConfig, Message, Utf8Bytes};
@@ -9,6 +10,7 @@ use tracing::{debug, error, info, trace, warn};
 use crate::config::Config;
 
 const MESSAGE_BUFFER_CAPACITY: usize = 1024;
+const TCP_BACKLOG: u32 = 1024;
 const WRITE_BATCH_SIZE: usize = 64;
 const WRITE_BATCH_BYTES_LIMIT: usize = 256 * 1024;
 
@@ -28,8 +30,15 @@ impl MessageBus {
     }
 
     pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let addr = format!("{}:{}", self.config.host, self.config.port);
-        let listener = TcpListener::bind(&addr).await?;
+        let addr: SocketAddr = format!("{}:{}", self.config.host, self.config.port).parse()?;
+        let socket = if addr.is_ipv6() {
+            TcpSocket::new_v6()?
+        } else {
+            TcpSocket::new_v4()?
+        };
+        socket.set_reuseaddr(true)?;
+        socket.bind(addr)?;
+        let listener = socket.listen(TCP_BACKLOG)?;
         info!(
             "MessageBus listening on {} (route: {})",
             addr, self.config.route

--- a/src/message_bus.rs
+++ b/src/message_bus.rs
@@ -1,19 +1,21 @@
-use futures_util::{SinkExt, StreamExt};
+use futures_util::{Sink, SinkExt, StreamExt};
 use std::sync::Arc;
 use tokio::net::TcpListener;
-use tokio::sync::broadcast;
+use tokio::sync::broadcast::{self, error::RecvError, error::TryRecvError, Receiver};
 use tokio_tungstenite::accept_async_with_config;
-use tokio_tungstenite::tungstenite::protocol::{Message, WebSocketConfig};
+use tokio_tungstenite::tungstenite::{protocol::WebSocketConfig, Message, Utf8Bytes};
 use tracing::{debug, error, info, trace, warn};
 
 use crate::config::Config;
 
 const MESSAGE_BUFFER_CAPACITY: usize = 1024;
+const WRITE_BATCH_SIZE: usize = 64;
+const WRITE_BATCH_BYTES_LIMIT: usize = 256 * 1024;
 
 #[derive(Clone)]
 pub struct MessageBus {
     config: Arc<Config>,
-    message_tx: broadcast::Sender<Message>,
+    message_tx: broadcast::Sender<Utf8Bytes>,
 }
 
 impl MessageBus {
@@ -62,7 +64,7 @@ impl MessageBus {
                 match message {
                     Ok(Message::Text(text)) => {
                         trace!("Received message: {}", text);
-                        let _ = read_bus.message_tx.send(Message::Text(text));
+                        let _ = read_bus.message_tx.send(text);
                     }
                     Ok(Message::Close(_)) => {
                         debug!("WebSocket connection closed");
@@ -79,18 +81,24 @@ impl MessageBus {
 
         let write_handle = tokio::spawn(async move {
             loop {
-                match rx.recv().await {
-                    Ok(message) => {
-                        if let Err(e) = write.send(message).await {
-                            error!("Error sending message: {}", e);
-                            break;
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                match flush_next_batch(
+                    &mut write,
+                    &mut rx,
+                    WRITE_BATCH_SIZE,
+                    WRITE_BATCH_BYTES_LIMIT,
+                )
+                .await
+                {
+                    Ok(BatchState::Continue) => {}
+                    Ok(BatchState::SlowConsumer(skipped)) => {
                         warn!("Slow consumer lagged, dropped {} messages — disconnecting", skipped);
                         break;
                     }
-                    Err(broadcast::error::RecvError::Closed) => {
+                    Ok(BatchState::Closed) => {
+                        break;
+                    }
+                    Err(e) => {
+                        error!("Error sending message: {}", e);
                         break;
                     }
                 }
@@ -115,9 +123,57 @@ impl MessageBus {
 
     fn websocket_config(&self) -> WebSocketConfig {
         let max_message_size = self.config.max_msg_size as usize * 1024 * 1024;
-        let mut config = WebSocketConfig::default();
-        config.max_message_size = Some(max_message_size);
-        config.max_frame_size = Some(max_message_size);
-        config
+        WebSocketConfig::default()
+            .max_message_size(Some(max_message_size))
+            .max_frame_size(Some(max_message_size))
     }
+}
+
+enum BatchState {
+    Continue,
+    SlowConsumer(u64),
+    Closed,
+}
+
+async fn flush_next_batch<S>(
+    write: &mut S,
+    rx: &mut Receiver<Utf8Bytes>,
+    batch_size: usize,
+    batch_bytes_limit: usize,
+) -> Result<BatchState, S::Error>
+where
+    S: Sink<Message> + Unpin,
+{
+    let first = match rx.recv().await {
+        Ok(message) => message,
+        Err(RecvError::Lagged(skipped)) => return Ok(BatchState::SlowConsumer(skipped)),
+        Err(RecvError::Closed) => return Ok(BatchState::Closed),
+    };
+
+    let mut batched_bytes = first.len();
+    write.feed(Message::Text(first)).await?;
+    let mut batched_messages = 1;
+
+    let mut close_state = BatchState::Continue;
+    while batched_messages < batch_size && batched_bytes < batch_bytes_limit {
+        match rx.try_recv() {
+            Ok(message) => {
+                batched_bytes += message.len();
+                write.feed(Message::Text(message)).await?;
+                batched_messages += 1;
+            }
+            Err(TryRecvError::Empty) => break,
+            Err(TryRecvError::Lagged(skipped)) => {
+                close_state = BatchState::SlowConsumer(skipped);
+                break;
+            }
+            Err(TryRecvError::Closed) => {
+                close_state = BatchState::Closed;
+                break;
+            }
+        }
+    }
+
+    write.flush().await?;
+    Ok(close_state)
 }

--- a/src/message_bus.rs
+++ b/src/message_bus.rs
@@ -1,24 +1,27 @@
 use futures_util::{SinkExt, StreamExt};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tokio::net::TcpListener;
-use tokio::sync::mpsc::{self, UnboundedSender};
+use tokio::sync::broadcast;
 use tokio_tungstenite::accept_async_with_config;
 use tokio_tungstenite::tungstenite::protocol::{Message, WebSocketConfig};
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::config::Config;
+
+const MESSAGE_BUFFER_CAPACITY: usize = 1024;
 
 #[derive(Clone)]
 pub struct MessageBus {
     config: Arc<Config>,
-    connections: Arc<Mutex<Vec<UnboundedSender<Message>>>>,
+    message_tx: broadcast::Sender<Message>,
 }
 
 impl MessageBus {
     pub fn new(config: Config) -> Self {
+        let (message_tx, _) = broadcast::channel(MESSAGE_BUFFER_CAPACITY);
         Self {
             config: Arc::new(config),
-            connections: Arc::new(Mutex::new(Vec::new())),
+            message_tx,
         }
     }
 
@@ -48,15 +51,10 @@ impl MessageBus {
     ) -> Result<(), Box<dyn std::error::Error>> {
         stream.set_nodelay(true)?;
         let ws_stream = accept_async_with_config(stream, Some(self.websocket_config())).await?;
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        let tx_clone = tx.clone();
-        {
-            let mut connections = self.connections.lock().unwrap();
-            connections.push(tx);
-        }
-        debug!("WebSocket connection opened (total: {})", self.connections.lock().unwrap().len());
-
         let (mut write, mut read) = ws_stream.split();
+        let mut rx = self.message_tx.subscribe();
+
+        debug!("WebSocket connection opened (subscribers: {})", self.message_tx.receiver_count());
 
         let read_bus = self.clone();
         let read_handle = tokio::spawn(async move {
@@ -64,7 +62,7 @@ impl MessageBus {
                 match message {
                     Ok(Message::Text(text)) => {
                         trace!("Received message: {}", text);
-                        read_bus.broadcast_message(&text).await;
+                        let _ = read_bus.message_tx.send(Message::Text(text));
                     }
                     Ok(Message::Close(_)) => {
                         debug!("WebSocket connection closed");
@@ -77,34 +75,42 @@ impl MessageBus {
                     }
                 }
             }
-            read_bus.remove_connection(&tx_clone).await;
         });
 
         let write_handle = tokio::spawn(async move {
-            while let Some(message) = rx.recv().await {
-                if let Err(e) = write.send(message).await {
-                    error!("Error sending message: {}", e);
-                    break;
+            loop {
+                match rx.recv().await {
+                    Ok(message) => {
+                        if let Err(e) = write.send(message).await {
+                            error!("Error sending message: {}", e);
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                        warn!("Slow consumer lagged, dropped {} messages — disconnecting", skipped);
+                        break;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        break;
+                    }
                 }
             }
         });
 
+        let mut read_handle = read_handle;
+        let mut write_handle = write_handle;
         tokio::select! {
-            _ = read_handle => {},
-            _ = write_handle => {},
+            _ = &mut read_handle => {
+                write_handle.abort();
+            },
+            _ = &mut write_handle => {
+                read_handle.abort();
+            },
         }
+        let _ = read_handle.await;
+        let _ = write_handle.await;
 
         Ok(())
-    }
-
-    async fn broadcast_message(&self, message: &str) {
-        let mut connections = self.connections.lock().unwrap();
-        connections.retain(|tx| tx.send(Message::Text(message.to_string())).is_ok());
-    }
-
-    async fn remove_connection(&self, tx: &UnboundedSender<Message>) {
-        let mut connections = self.connections.lock().unwrap();
-        connections.retain(|conn| !conn.same_channel(tx));
     }
 
     fn websocket_config(&self) -> WebSocketConfig {

--- a/src/message_bus.rs
+++ b/src/message_bus.rs
@@ -2,18 +2,16 @@ use futures_util::{SinkExt, StreamExt};
 use std::sync::{Arc, Mutex};
 use tokio::net::TcpListener;
 use tokio::sync::mpsc::{self, UnboundedSender};
-use tokio_tungstenite::accept_async;
-use tokio_tungstenite::tungstenite::protocol::Message;
-use tracing::{debug, error, info, trace, warn};
+use tokio_tungstenite::accept_async_with_config;
+use tokio_tungstenite::tungstenite::protocol::{Message, WebSocketConfig};
+use tracing::{debug, error, info, trace};
 
 use crate::config::Config;
-use EventEmitter::EventEmitter;
 
 #[derive(Clone)]
 pub struct MessageBus {
     config: Arc<Config>,
     connections: Arc<Mutex<Vec<UnboundedSender<Message>>>>,
-    event_emitter: Arc<Mutex<EventEmitter>>,
 }
 
 impl MessageBus {
@@ -21,7 +19,6 @@ impl MessageBus {
         Self {
             config: Arc::new(config),
             connections: Arc::new(Mutex::new(Vec::new())),
-            event_emitter: Arc::new(Mutex::new(EventEmitter::new())),
         }
     }
 
@@ -49,7 +46,8 @@ impl MessageBus {
         &self,
         stream: tokio::net::TcpStream,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let ws_stream = accept_async(stream).await?;
+        stream.set_nodelay(true)?;
+        let ws_stream = accept_async_with_config(stream, Some(self.websocket_config())).await?;
         let (tx, mut rx) = mpsc::unbounded_channel();
         let tx_clone = tx.clone();
         {
@@ -65,14 +63,8 @@ impl MessageBus {
             while let Some(message) = read.next().await {
                 match message {
                     Ok(Message::Text(text)) => {
-                        if text.len() as u32 > read_bus.config.max_msg_size * 1024 * 1024 {
-                            warn!("Message size exceeds maximum allowed size");
-                            break;
-                        }
                         trace!("Received message: {}", text);
                         read_bus.broadcast_message(&text).await;
-                        let event_emitter = read_bus.event_emitter.lock().unwrap();
-                        event_emitter.emit(&text);
                     }
                     Ok(Message::Close(_)) => {
                         debug!("WebSocket connection closed");
@@ -113,5 +105,13 @@ impl MessageBus {
     async fn remove_connection(&self, tx: &UnboundedSender<Message>) {
         let mut connections = self.connections.lock().unwrap();
         connections.retain(|conn| !conn.same_channel(tx));
+    }
+
+    fn websocket_config(&self) -> WebSocketConfig {
+        let max_message_size = self.config.max_msg_size as usize * 1024 * 1024;
+        let mut config = WebSocketConfig::default();
+        config.max_message_size = Some(max_message_size);
+        config.max_frame_size = Some(max_message_size);
+        config
     }
 }


### PR DESCRIPTION
## Summary

   - Replace `Arc<Mutex<Vec<UnboundedSender>>>` fanout with `tokio::sync::broadcast` — removes the global lock from the message path
   - Upgrade tokio-tungstenite to 0.28, broadcast `Utf8Bytes` instead of cloning strings (refcount bump, not copy)
   - Batch outbound writes with `feed()`+`flush()` to reduce per-message syscall overhead
   - Add `tracing` with `RUST_LOG` env filter — connection lifecycle at `debug!`, per-message at `trace!`, errors at `error!`
   - Set TCP listen backlog to 1024 (was OS default ~128) — fixes connection rejections at 100+ simultaneous clients
   - Make broadcast buffer capacity configurable (`OVOS_BUS_MSG_BUFFER_CAPACITY`, default 1024)
   - Log actual vs max size on oversized message rejection
   - Fix `JoinHandle polled after completion` panic in connection cleanup
   - Remove unused `EventEmitter` dependency
   - Enable `TCP_NODELAY` on accepted sockets
   - Move max message size enforcement into tungstenite's `WebSocketConfig`
   - Document architecture, slow consumer policy, and known limitations in README

   Based on work by @goldyfruit in #24, #25, #26 — those PRs can be closed once this merges.

   ## Test results

   Stress tested on macOS (Apple Silicon):

   | Scenario | Result |
   |----------|--------|
   | 100 clients, 500 msgs | 0 drops, 0 rejections |
   | 1,000 clients, 50 msgs | 0 drops, 0 rejections, 0.3s connect |
   | 10,000 clients, 50 msgs | 0 drops, 0 rejections, 4.3s connect |
   | 50-way write contention (500K deliveries) | 0 drops |
   | Reconnection storm (500 reconnects while streaming) | 0 message loss |
   | 60s idle connections | all survived |

   Before this PR, 100 simultaneous clients caused 28 connection rejections and 31-second median latency.

   ## Known limitations

   - **Slow consumer disconnect**: subscribers that fall >1024 messages behind are disconnected. Intentional tradeoff — caps memory, prevents one stalled client from degrading the bus. Buffer size is configurable.
   - **No server-side WebSocket pings**: dead connections are detected on next write failure or OS TCP keepalive. A silently-disappeared client holds its subscription until the TCP stack notices. Harmless in practice (subscription sits
   idle, cleaned up on next failed write), but the server won't proactively detect it.
   - **No per-message routing**: every message fans out to every client. Matches OVOS bus protocol.

   ## Test plan

   - [ ] Verify `RUST_LOG=info` shows startup banner and connection events
   - [ ] Verify `OVOS_BUS_MSG_BUFFER_CAPACITY` env var is respected
   - [ ] Run benchmark harness against Tornado/webrockets/Rust to compare post-refactor numbers
   - [ ] Test on Raspberry Pi (the target deployment platform)