### PR TITLE
fix(deps): bump bytes and rand to clear Dependabot alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"
@@ -364,9 +364,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",


### PR DESCRIPTION
## Summary

Routine `cargo update -p bytes -p rand` clears both open Dependabot alerts.

| Package | From | To | Severity | Alert |
|---|---|---|---|---|
| bytes | 1.11.0 | 1.11.1 | medium | integer overflow in `BytesMut::reserve` |
| rand | 0.9.2 | 0.9.4 | low | unsound with custom logger using `rand::rng()` |

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — 3/3 pass
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)